### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/utils/pythonScriptExecutor.ts
+++ b/src/utils/pythonScriptExecutor.ts
@@ -65,7 +65,7 @@ export class PythonScriptExecutor {
      * @returns A single string with all arguments properly escaped
      */
     private escapeCommandArguments(args: string[]): string {
-        return args.map(arg => `"${arg.replace(/"/g, '\\"')}"`).join(' ');
+        return args.map(arg => `"${arg.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(' ');
     }
 
     /**


### PR DESCRIPTION
Potential fix for [https://github.com/blackwhitehere/acme-portal/security/code-scanning/1](https://github.com/blackwhitehere/acme-portal/security/code-scanning/1)

To fix the problem, we need to ensure that both backslashes and double quotes are properly escaped in command-line arguments. The best way to do this is to first escape all backslashes (`\` → `\\`), then escape all double quotes (`"` → `\"`). This order is important to avoid double-escaping. The fix should be applied in the `escapeCommandArguments` method in `src/utils/pythonScriptExecutor.ts`, specifically on line 68. No new imports are needed, as this can be done with standard JavaScript string methods. The replacement should ensure that all arguments are safely quoted and escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
